### PR TITLE
Apply RAIC rules and sort supervisor requests

### DIFF
--- a/1_Formulario.py
+++ b/1_Formulario.py
@@ -1,27 +1,25 @@
 import streamlit as st
-from datetime import datetime
+from datetime import datetime, timedelta
 import re
 import utils  # Your utility functions for Supabase, tokens, and email
 
 # Project ID for Supabase calls
-PROJECT_ID = "lperiyftrgzchrzvutgx" # Replace with your actual Supabase project ID
+PROJECT_ID = "lperiyftrgzchrzvutgx"  # Replace with your actual Supabase project ID
+
 
 # Function to validate email format
 def validate_email(email):
-    pattern = r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$'
+    pattern = r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$"
     return re.match(pattern, email) is not None
 
-st.set_page_config(
-    page_title="Solicitar Cambio",
-    page_icon="✈️",
-    layout="centered"
-)
+
+st.set_page_config(page_title="Solicitar Cambio", page_icon="✈️", layout="centered")
 
 
 st.title("✈️ Formulario de Solicitud de Cambio de Turno")
 
 # Load employees data for dropdowns
-if 'employees_data' not in st.session_state:
+if "employees_data" not in st.session_state:
     with st.spinner("Cargando lista de empleados..."):
         st.session_state.employees_data = utils.get_all_employees(PROJECT_ID)
 
@@ -33,12 +31,15 @@ if not employees:
     st.info("💡 Contacta al administrador para que agregue empleados al sistema.")
     st.stop()
 
-employee_names = ["Seleccionar empleado..."] + [emp['full_name'] for emp in employees]
+employee_names = ["Seleccionar empleado..."] + [emp["full_name"] for emp in employees]
+
+# RAIC color options
+raic_options = ["Morado", "Amarillo", "Verde"]
 
 # Initialize session state for form data
-if 'requester_data' not in st.session_state:
+if "requester_data" not in st.session_state:
     st.session_state.requester_data = {}
-if 'cover_data' not in st.session_state:
+if "cover_data" not in st.session_state:
     st.session_state.cover_data = {}
 
 # Add refresh button for employee list
@@ -50,16 +51,19 @@ with col2:
 
 # Form sections outside of st.form for better reactivity
 st.header("Detalles del Turno")
-date_request_input = st.date_input("Fecha del turno a Cambiar", value=datetime.today())
+min_shift_date = datetime.now().date() + timedelta(days=1)
+date_request_input = st.date_input(
+    "Fecha del turno a Cambiar", value=min_shift_date, min_value=min_shift_date
+)
 
 # Flight options with schedules
 flight_options = [
     "Seleccionar vuelo...",
     "AV255 (5:00-10:00)",
-    "AV619 (04:00-09:00)", # NUEVO VUELO
-    "AV627 (13:00-17:30)", 
+    "AV619 (04:00-09:00)",  # NUEVO VUELO
+    "AV627 (13:00-17:30)",
     "AV205 (20:00-00:30+1)",  # Overnight flight - arrives next day
-    "AV625 (20:00-02:30+1)"   # Overnight flight - arrives next day
+    "AV625 (20:00-02:30+1)",  # Overnight flight - arrives next day
 ]
 
 selected_flight = st.selectbox("Número de Vuelo", flight_options)
@@ -73,78 +77,179 @@ else:
 st.header("Empleado que Solicita el Cambio")
 
 # Dropdown for requester
-selected_requester = st.selectbox("Seleccionar solicitante", employee_names, key="requester_select")
+selected_requester = st.selectbox(
+    "Seleccionar solicitante", employee_names, key="requester_select"
+)
 
 # Auto-fill fields for requester
 if selected_requester != "Seleccionar empleado...":
-    requester_employee = next((emp for emp in employees if emp['full_name'] == selected_requester), None)
+    requester_employee = next(
+        (emp for emp in employees if emp["full_name"] == selected_requester), None
+    )
     if requester_employee:
         st.session_state.requester_data = requester_employee
-        requester_name = st.text_input("Nombre del solicitante", value=requester_employee['full_name'], disabled=True)
-        requester_employee_number = st.text_input("Color del RAIC (Solicitante)", value=requester_employee['raic_color'], disabled=True)
-        requester_email = st.text_input("Email del solicitante", value=requester_employee['email'], disabled=True)
+        requester_name = st.text_input(
+            "Nombre del solicitante",
+            value=requester_employee["full_name"],
+            disabled=True,
+        )
+        requester_employee_number = st.selectbox(
+            "Color del RAIC (Solicitante)",
+            raic_options,
+            index=(
+                raic_options.index(requester_employee["raic_color"])
+                if requester_employee["raic_color"] in raic_options
+                else 0
+            ),
+            disabled=True,
+        )
+        requester_email = st.text_input(
+            "Email del solicitante", value=requester_employee["email"], disabled=True
+        )
     else:
         requester_name = st.text_input("Nombre del solicitante")
-        requester_employee_number = st.text_input("Color del RAIC (Solicitante)")
-        requester_email = st.text_input("Email del solicitante", placeholder="ejemplo@empresa.com")
+        requester_employee_number = st.selectbox(
+            "Color del RAIC (Solicitante)", ["Seleccionar color..."] + raic_options
+        )
+        requester_email = st.text_input(
+            "Email del solicitante", placeholder="ejemplo@empresa.com"
+        )
 else:
     requester_name = st.text_input("Nombre del solicitante")
-    requester_employee_number = st.text_input("Color del RAIC (Solicitante)")
-    requester_email = st.text_input("Email del solicitante", placeholder="ejemplo@empresa.com")
+    requester_employee_number = st.selectbox(
+        "Color del RAIC (Solicitante)", ["Seleccionar color..."] + raic_options
+    )
+    requester_email = st.text_input(
+        "Email del solicitante", placeholder="ejemplo@empresa.com"
+    )
 
 # Option to add manual data if not in dropdown
 if selected_requester == "Seleccionar empleado...":
-    st.caption("💡 ¿El empleado no está en la lista? Completa manualmente los campos o contacta al administrador para agregarlo al sistema.")
+    st.caption(
+        "💡 ¿El empleado no está en la lista? Completa manualmente los campos o contacta al administrador para agregarlo al sistema."
+    )
 
 st.header("Empleado que Cubrirá el Turno")
 
 # Dropdown for cover employee
-selected_cover = st.selectbox("Seleccionar compañero que cubrirá", employee_names, key="cover_select")
+selected_cover = st.selectbox(
+    "Seleccionar compañero que cubrirá", employee_names, key="cover_select"
+)
 
 # Prevent selecting the same person for both roles
-if selected_requester != "Seleccionar empleado..." and selected_cover == selected_requester:
-    st.error("❌ El solicitante y el compañero que cubrirá no pueden ser la misma persona.")
+if (
+    selected_requester != "Seleccionar empleado..."
+    and selected_cover == selected_requester
+):
+    st.error(
+        "❌ El solicitante y el compañero que cubrirá no pueden ser la misma persona."
+    )
 
 # Auto-fill fields for cover employee
 if selected_cover != "Seleccionar empleado...":
-    cover_employee = next((emp for emp in employees if emp['full_name'] == selected_cover), None)
+    cover_employee = next(
+        (emp for emp in employees if emp["full_name"] == selected_cover), None
+    )
     if cover_employee:
         st.session_state.cover_data = cover_employee
-        cover_name = st.text_input("Nombre del compañero que cubrirá", value=cover_employee['full_name'], disabled=True)
-        cover_employee_number = st.text_input("Color del RAIC (Cubridor)", value=cover_employee['raic_color'], disabled=True)
-        cover_email = st.text_input("Email del compañero que cubrirá", value=cover_employee['email'], disabled=True)
+        cover_name = st.text_input(
+            "Nombre del compañero que cubrirá",
+            value=cover_employee["full_name"],
+            disabled=True,
+        )
+        cover_employee_number = st.selectbox(
+            "Color del RAIC (Cubridor)",
+            raic_options,
+            index=(
+                raic_options.index(cover_employee["raic_color"])
+                if cover_employee["raic_color"] in raic_options
+                else 0
+            ),
+            disabled=True,
+        )
+        cover_email = st.text_input(
+            "Email del compañero que cubrirá",
+            value=cover_employee["email"],
+            disabled=True,
+        )
     else:
         cover_name = st.text_input("Nombre del compañero que cubrirá")
-        cover_employee_number = st.text_input("Color del RAIC (Cubridor)")
-        cover_email = st.text_input("Email del compañero que cubrirá", placeholder="compañero@empresa.com")
+        cover_employee_number = st.selectbox(
+            "Color del RAIC (Cubridor)",
+            ["Seleccionar color..."] + raic_options,
+            key="manual_cover_color",
+        )
+        cover_email = st.text_input(
+            "Email del compañero que cubrirá", placeholder="compañero@empresa.com"
+        )
 else:
     cover_name = st.text_input("Nombre del compañero que cubrirá")
-    cover_employee_number = st.text_input("Color del RAIC (Cubridor)")
-    cover_email = st.text_input("Email del compañero que cubrirá", placeholder="compañero@empresa.com")
+    cover_employee_number = st.selectbox(
+        "Color del RAIC (Cubridor)",
+        ["Seleccionar color..."] + raic_options,
+        key="manual_cover_color_noemp",
+    )
+    cover_email = st.text_input(
+        "Email del compañero que cubrirá", placeholder="compañero@empresa.com"
+    )
 
 # Option to add manual data if not in dropdown
 if selected_cover == "Seleccionar empleado...":
-    st.caption("💡 ¿El empleado no está en la lista? Completa manualmente los campos o contacta al administrador para agregarlo al sistema.")
+    st.caption(
+        "💡 ¿El empleado no está en la lista? Completa manualmente los campos o contacta al administrador para agregarlo al sistema."
+    )
 
-st.caption("⚠️ Verifica cuidadosamente el email - es la única forma de contactar al compañero")
+st.caption(
+    "⚠️ Verifica cuidadosamente el email - es la única forma de contactar al compañero"
+)
 
 # Submit button outside of form
 submit_button = st.button("Enviar Solicitud", type="primary")
 
 if submit_button:
     # Validation checks
-    if not all([date_request_input, flight_number, requester_name, requester_employee_number, requester_email, cover_name, cover_employee_number, cover_email]):
+    if not all(
+        [
+            date_request_input,
+            flight_number,
+            requester_name,
+            requester_employee_number,
+            requester_email,
+            cover_name,
+            cover_employee_number,
+            cover_email,
+        ]
+    ):
         st.error("Por favor, completa todos los campos.")
-    elif selected_requester != "Seleccionar empleado..." and selected_cover == selected_requester:
-        st.error("❌ El solicitante y el compañero que cubrirá no pueden ser la misma persona.")
+    elif (
+        selected_requester != "Seleccionar empleado..."
+        and selected_cover == selected_requester
+    ):
+        st.error(
+            "❌ El solicitante y el compañero que cubrirá no pueden ser la misma persona."
+        )
     elif not validate_email(requester_email):
-        st.error("❌ El email del solicitante no tiene un formato válido. Por favor, verifica que incluya @ y un dominio válido.")
+        st.error(
+            "❌ El email del solicitante no tiene un formato válido. Por favor, verifica que incluya @ y un dominio válido."
+        )
     elif not validate_email(cover_email):
-        st.error("❌ El email del compañero que cubrirá no tiene un formato válido. Por favor, verifica que incluya @ y un dominio válido.")
+        st.error(
+            "❌ El email del compañero que cubrirá no tiene un formato válido. Por favor, verifica que incluya @ y un dominio válido."
+        )
+    elif datetime.combine(
+        date_request_input, datetime.min.time()
+    ) < datetime.now() + timedelta(days=1):
+        st.error(
+            "Las solicitudes deben enviarse con al menos 24 horas de anticipación."
+        )
+    elif cover_employee_number == "Verde" and requester_employee_number != "Verde":
+        st.error("Un RAIC verde solo puede cubrir a otro verde.")
     else:
         with st.spinner("Procesando la solicitud..."):
             request_details = {
-                "date_request": str(date_request_input), # Ensure it's a string for Supabase if not handled by client
+                "date_request": str(
+                    date_request_input
+                ),  # Ensure it's a string for Supabase if not handled by client
                 "flight_number": flight_number,
                 "requester_name": requester_name,
                 "requester_employee_number": requester_employee_number,
@@ -152,7 +257,7 @@ if submit_button:
                 "cover_name": cover_name,
                 "cover_employee_number": cover_employee_number,
                 "cover_email": cover_email,
-                "supervisor_status": "pending" # Initial status
+                "supervisor_status": "pending",  # Initial status
             }
 
             # 1. Save data to Supabase (shift_requests table)
@@ -169,18 +274,20 @@ if submit_button:
 
                 if token:
                     # 3. Create a unique link with the token for Streamlit Cloud
-                    accept_url = f"https://shifttrade.streamlit.app/Solicitud?token={token}"
+                    accept_url = (
+                        f"https://shifttrade.streamlit.app/Solicitud?token={token}"
+                    )
 
                     # 4. Send the link by email to the covering employee
                     st.caption("Enviando correo electrónico...")
                     email_subject = "Solicitud de Cobertura de Turno"
-                    
+
                     # Get current date for the request
                     fecha_solicitud = datetime.now().strftime("%d/%m/%Y")
-                    
+
                     # Get flight schedule information for email
                     flight_schedule = utils.get_flight_schedule_info(flight_number)
-                    
+
                     email_body = f"""Hola {cover_name},
 
 {requester_name} ha solicitado que cubras su turno para el vuelo {flight_number} el {utils.format_date(date_request_input)}.
@@ -196,13 +303,19 @@ Para aceptar, por favor haz clic en el siguiente enlace (válido por 24 horas):
 {accept_url}
 
 Gracias."""
-                    email_sent = utils.send_email(cover_email, email_subject, email_body)
+                    email_sent = utils.send_email(
+                        cover_email, email_subject, email_body
+                    )
                     progress_bar.progress(100)
 
                     if email_sent:
                         st.success(f"✅ Solicitud enviada con ID: {shift_request_id}")
-                        st.info(f"📧 Se ha enviado un correo a **{cover_email}** con el enlace para aceptar el cambio.")
-                        st.info("💡 **Nota importante:** Si el compañero no recibe el correo, verifica que:")
+                        st.info(
+                            f"📧 Se ha enviado un correo a **{cover_email}** con el enlace para aceptar el cambio."
+                        )
+                        st.info(
+                            "💡 **Nota importante:** Si el compañero no recibe el correo, verifica que:"
+                        )
                         st.write("• El email esté escrito correctamente")
                         st.write("• Revise su carpeta de spam/correo no deseado")
                         st.write("• El dominio del email sea válido")
@@ -210,16 +323,22 @@ Gracias."""
                         st.success(f"✅ Solicitud guardada con ID: {shift_request_id}")
                         st.error("❌ **Error al enviar el correo de aceptación**")
                         st.warning("⚠️ **Posibles causas del error:**")
-                        st.write("• El email ingresado podría tener un error de digitación")
+                        st.write(
+                            "• El email ingresado podría tener un error de digitación"
+                        )
                         st.write("• El dominio del email no existe")
                         st.write("• Problemas temporales del servidor de correo")
                         st.info("🔧 **Soluciones:**")
                         st.write("• Verifica que el email esté escrito correctamente")
                         st.write("• Contacta directamente al compañero con el enlace:")
                         st.code(accept_url)
-                        st.write("• O contacta al administrador para reenviar el correo")
+                        st.write(
+                            "• O contacta al administrador para reenviar el correo"
+                        )
                 else:
-                    st.error("Error al generar el token de aceptación. La solicitud fue guardada, pero el correo no pudo ser enviado.")
+                    st.error(
+                        "Error al generar el token de aceptación. La solicitud fue guardada, pero el correo no pudo ser enviado."
+                    )
             else:
                 st.error("Error al guardar la solicitud en la base de datos.")
 

--- a/pages/3_Supervisor.py
+++ b/pages/3_Supervisor.py
@@ -1,170 +1,98 @@
 import streamlit as st
-import pandas as pd # Import pandas for DataFrame
+import pandas as pd  # Import pandas for DataFrame
 from datetime import datetime
-import utils # Your utility functions
+import utils  # Your utility functions
 
-# Project ID for Supabase calls
-PROJECT_ID = "lperiyftrgzchrzvutgx" # Replace with your actual Supabase project ID
-CORRECT_PASSWORD = "supervisor2025"
 
-st.set_page_config(
-    page_title="Panel del Supervisor",
-    page_icon="👑",
-    layout="wide"
-)
+def render_pending_request(req):
+    """Render a single pending request with approve/reject actions."""
+    req_id = req.get("id")
+    formatted_date = utils.format_date(req.get("date_request", "N/A"))
+    expander_title = f"Fecha: {formatted_date} - Vuelo: {req.get('flight_number', 'N/A')} - Solicitante: {req.get('requester_name', 'N/A')}"
 
-# Password protection
-if 'supervisor_password_correct' not in st.session_state:
-    st.session_state.supervisor_password_correct = False
+    with st.expander(expander_title):
+        with st.form(key=f"form_{req_id}"):
+            st.markdown(
+                f"""
+                - **Fecha Solicitud:** {utils.format_date(req.get('date_request', 'N/A'))}
+                - **Número de Vuelo:** {req.get('flight_number')}
+                - **Solicitante:** {req.get('requester_name')} ({req.get('requester_employee_number')}, {req.get('requester_email')})
+                - **Cubridor:** {req.get('cover_name')} ({req.get('cover_employee_number')}, {req.get('cover_email')})
+                """
+            )
 
-if not st.session_state.supervisor_password_correct:
-    st.title("👑 Acceso al Panel de Supervisor")
-    password_attempt = st.text_input("Ingrese la contraseña para acceder:", type="password", key="supervisor_page_password")
-    if password_attempt:
-        if password_attempt == CORRECT_PASSWORD:
-            st.session_state.supervisor_password_correct = True
-            st.rerun()
-        else:
-            st.error("Contraseña incorrecta.")
-    st.stop() # Do not render the rest of the page if password is not correct
+            has_cover_accepted = (
+                req.get("date_accepted_by_cover") is not None
+                and req.get("date_accepted_by_cover") != "N/A"
+            )
+            if has_cover_accepted:
+                st.success(
+                    f"✅ **ACEPTADO POR EL CUBRIDOR:** {utils.format_date(req.get('date_accepted_by_cover'))}"
+                )
+            else:
+                st.error("❌ **PENDIENTE DE ACEPTACIÓN POR EL CUBRIDOR**")
+                st.warning(
+                    "⚠️ El cubridor aún no ha aceptado esta solicitud. No se recomienda aprobarla hasta que el cubridor confirme."
+                )
 
-# --- Main Page Content Starts Here ---
-st.title("👑 Panel de Aprobación del Supervisor")
+            supervisor_name_input_val = st.text_input(
+                "Nombre del Supervisor", key=f"supervisor_name_form_{req_id}"
+            )
+            supervisor_password_input_val = st.text_input(
+                "Contraseña del Supervisor",
+                type="password",
+                key=f"supervisor_password_form_{req_id}",
+            )
+            supervisor_comments_val = st.text_area(
+                "Comentarios (opcional para aprobación, obligatorio para rechazo)",
+                key=f"comments_form_{req_id}",
+            )
 
-# Initialize session state for view mode if it doesn't exist
-if 'view_mode' not in st.session_state:
-    st.session_state.view_mode = 'pending_requests' # Default view
+            col1, col2, _ = st.columns([1, 1, 5])
+            with col1:
+                approve_submitted = st.form_submit_button(
+                    "✅ Aprobar", type="primary", disabled=not has_cover_accepted
+                )
+            with col2:
+                reject_submitted = st.form_submit_button("❌ Rechazar")
 
-st.sidebar.header("Acciones")
-if st.sidebar.button("Refrescar Datos"):
-    # El método spinner no está disponible para st.sidebar
-    refresh_status = st.sidebar.empty()
-    refresh_status.info("Refrescando datos...")
-    # Clear relevant session state to force data refresh if needed
-    if 'all_requests_for_history' in st.session_state:
-        del st.session_state.all_requests_for_history
-    if 'pending_requests_data' in st.session_state:
-        del st.session_state.pending_requests_data
-    st.rerun()
+        if approve_submitted:
+            if not supervisor_name_input_val:
+                st.warning("Por favor, ingresa tu nombre de supervisor.")
+            elif supervisor_password_input_val != CORRECT_PASSWORD:
+                st.error("Contraseña del supervisor incorrecta.")
+            elif not has_cover_accepted:
+                st.error(
+                    "No se puede aprobar esta solicitud porque el cubridor aún no la ha aceptado."
+                )
+            else:
+                with st.spinner(f"Aprobando solicitud {req_id}..."):
+                    progress_bar = st.progress(0)
+                    st.caption("Actualizando estado en la base de datos...")
+                    now_utc = datetime.utcnow()
+                    updates = {
+                        "supervisor_status": "approved",
+                        "supervisor_decision_date": now_utc.isoformat(),
+                        "supervisor_comments": supervisor_comments_val,
+                        "supervisor_name": supervisor_name_input_val,
+                    }
+                    update_success = utils.update_shift_request_status(
+                        req_id, updates, PROJECT_ID
+                    )
+                    progress_bar.progress(50)
 
-st.sidebar.markdown("---")
+                    if update_success:
+                        st.caption("Enviando notificaciones por correo...")
+                        fecha_aprobacion = datetime.now().strftime("%d/%m/%Y")
+                        fecha_vuelo = utils.format_date(req.get("date_request"))
+                        fecha_aceptacion = (
+                            utils.format_date(req.get("date_accepted_by_cover"))
+                            if req.get("date_accepted_by_cover")
+                            else "N/A"
+                        )
 
-# Sidebar buttons to switch views
-if st.sidebar.button("Ver Solicitudes Pendientes", key="view_pending"):
-    st.session_state.view_mode = 'pending_requests'
-    st.rerun()
-
-if st.sidebar.button("Ver Historial de Solicitudes", key="view_history"):
-    st.session_state.view_mode = 'history_view'
-    st.rerun()
-
-st.sidebar.markdown("---")
-
-# Main panel content based on view_mode
-if st.session_state.view_mode == 'pending_requests':
-    st.header("Solicitudes Pendientes de Aprobación")
-    # 1. Display a list of all requests with `supervisor_status = 'pending'`
-    if 'pending_requests_data' not in st.session_state:
-        with st.spinner("Cargando solicitudes pendientes..."):
-            st.session_state.pending_requests_data = utils.get_pending_requests(PROJECT_ID)
-    
-    pending_requests = st.session_state.pending_requests_data
-
-    if not pending_requests:
-        st.info("No hay solicitudes de cambio de turno pendientes de aprobación.")
-        # Add a button to switch to history view if no pending requests
-        if st.button("Ver Historial de Solicitudes", key="pending_to_history_button"):
-            st.session_state.view_mode = 'history_view'
-            st.rerun()
-    else:
-        st.subheader(f"Total Pendientes: {len(pending_requests)}")
-        
-        # Ordenar solicitudes por fecha (más cercanas primero)
-        try:
-            # Convertir las fechas de string a objetos datetime para ordenarlas correctamente
-            for req in pending_requests:
-                if 'date_request' in req:
-                    # Intentar convertir a objeto datetime, si ya es un string ISO
-                    try:
-                        req['date_request_obj'] = datetime.fromisoformat(req['date_request'].replace('Z', '+00:00'))
-                    except (ValueError, AttributeError):
-                        # Si hay un error, asignar fecha lejana para que aparezca al final
-                        req['date_request_obj'] = datetime(2099, 1, 1)
-                else:
-                    req['date_request_obj'] = datetime(2099, 1, 1)  # Fecha lejana por defecto
-            
-            # Ordenar la lista por la fecha (más cercanas primero)
-            pending_requests = sorted(pending_requests, key=lambda x: x['date_request_obj'])
-        except Exception as e:
-            st.warning(f"No se pudieron ordenar las solicitudes por fecha: {e}")
-
-        for req in pending_requests:
-            req_id = req.get('id')
-            formatted_date = utils.format_date(req.get('date_request', 'N/A'))
-            expander_title = f"Fecha: {formatted_date} - Vuelo: {req.get('flight_number', 'N/A')} - Solicitante: {req.get('requester_name', 'N/A')}"
-            
-            with st.expander(expander_title):
-                # Each request will have its own form
-                with st.form(key=f"form_{req_id}"):
-                    # Información básica de la solicitud (can be outside the form if not submitted, but good to keep it grouped)
-                    st.markdown(f"""
-                    - **Fecha Solicitud:** {utils.format_date(req.get('date_request', 'N/A'))}
-                    - **Número de Vuelo:** {req.get('flight_number')}
-                    - **Solicitante:** {req.get('requester_name')} ({req.get('requester_employee_number')}, {req.get('requester_email')})
-                    - **Cubridor:** {req.get('cover_name')} ({req.get('cover_employee_number')}, {req.get('cover_email')})
-                    """)
-                    
-                    has_cover_accepted = req.get('date_accepted_by_cover') is not None and req.get('date_accepted_by_cover') != 'N/A'
-                    if has_cover_accepted:
-                        st.success(f"✅ **ACEPTADO POR EL CUBRIDOR:** {utils.format_date(req.get('date_accepted_by_cover'))}")
-                    else:
-                        st.error("❌ **PENDIENTE DE ACEPTACIÓN POR EL CUBRIDOR**")
-                        st.warning("⚠️ El cubridor aún no ha aceptado esta solicitud. No se recomienda aprobarla hasta que el cubridor confirme.")
-
-                    # Inputs within the form
-                    supervisor_name_input_val = st.text_input("Nombre del Supervisor", key=f"supervisor_name_form_{req_id}")
-                    supervisor_password_input_val = st.text_input("Contraseña del Supervisor", type="password", key=f"supervisor_password_form_{req_id}")
-                    supervisor_comments_val = st.text_area("Comentarios (opcional para aprobación, obligatorio para rechazo)", key=f"comments_form_{req_id}")
-
-                    # Submit buttons in columns
-                    col1, col2, col_spacer = st.columns([1,1,5]) # Adjusted spacer
-                    with col1:
-                        approve_submitted = st.form_submit_button("✅ Aprobar", type="primary", disabled=not has_cover_accepted)
-                    with col2:
-                        reject_submitted = st.form_submit_button("❌ Rechazar")
-
-                # Logic after form submission (outside the form definition)
-                if approve_submitted:
-                    if not supervisor_name_input_val:
-                        st.warning("Por favor, ingresa tu nombre de supervisor.")
-                    elif supervisor_password_input_val != CORRECT_PASSWORD: # Use defined CORRECT_PASSWORD
-                        st.error("Contraseña del supervisor incorrecta.")
-                    elif not has_cover_accepted: 
-                        st.error("No se puede aprobar esta solicitud porque el cubridor aún no la ha aceptado.")
-                    else:
-                        # approval_container = st.container() # Not strictly necessary here
-                        # with approval_container:
-                        with st.spinner(f"Aprobando solicitud {req_id}..."):
-                            progress_bar = st.progress(0)
-                            st.caption("Actualizando estado en la base de datos...")
-                            now_utc = datetime.utcnow()
-                            updates = {
-                                "supervisor_status": "approved",
-                                "supervisor_decision_date": now_utc.isoformat(),
-                                "supervisor_comments": supervisor_comments_val,
-                                "supervisor_name": supervisor_name_input_val
-                            }
-                            update_success = utils.update_shift_request_status(req_id, updates, PROJECT_ID)
-                            progress_bar.progress(50)
-                            
-                            if update_success:
-                                st.caption("Enviando notificaciones por correo...")
-                                fecha_aprobacion = datetime.now().strftime("%d/%m/%Y")
-                                fecha_vuelo = utils.format_date(req.get('date_request'))
-                                fecha_aceptacion = utils.format_date(req.get('date_accepted_by_cover')) if req.get('date_accepted_by_cover') else "N/A"
-                                
-                                requester_subject = "✅ Cambio de Turno APROBADO"
-                                requester_body = f"""Hola {req.get('requester_name')},
+                        requester_subject = "✅ Cambio de Turno APROBADO"
+                        requester_body = f"""Hola {req.get('requester_name')},
 
 ¡Excelentes noticias! Tu solicitud de cambio de turno ha sido APROBADA.
 
@@ -180,14 +108,14 @@ if st.session_state.view_mode == 'pending_requests':
 2. Aceptado por {req.get('cover_name')} el {fecha_aceptacion} ✅
 3. Aprobado por supervisor el {fecha_aprobacion} ✅
 
-**Comentarios del supervisor:** {supervisor_comments_val if supervisor_comments_val else "Sin comentarios adicionales"}
+**Comentarios del supervisor:** {supervisor_comments_val if supervisor_comments_val else 'Sin comentarios adicionales'}
 
 El cambio de turno está oficialmente autorizado.
 
 Saludos,
 ShiftTradeAV"""
-                                cover_subject = "✅ Cambio de Turno APROBADO"
-                                cover_body = f"""Hola {req.get('cover_name')},
+                        cover_subject = "✅ Cambio de Turno APROBADO"
+                        cover_body = f"""Hola {req.get('cover_name')},
 
 El cambio de turno que aceptaste cubrir ha sido APROBADO por el supervisor.
 
@@ -203,69 +131,79 @@ El cambio de turno que aceptaste cubrir ha sido APROBADO por el supervisor.
 2. Tú aceptaste el {fecha_aceptacion} ✅
 3. Aprobado por supervisor el {fecha_aprobacion} ✅
 
-**Comentarios del supervisor:** {supervisor_comments_val if supervisor_comments_val else "Sin comentarios adicionales"}
+**Comentarios del supervisor:** {supervisor_comments_val if supervisor_comments_val else 'Sin comentarios adicionales'}
 
 Gracias por tu colaboración. El cambio está oficialmente autorizado.
 
 Saludos,
 ShiftTradeAV"""
-                                email1 = utils.send_email_with_calendar(
-                                    req.get('requester_email'), 
-                                    requester_subject, 
-                                    requester_body,
-                                    req, 
-                                    is_for_requester=True
-                                )
-                                email2 = utils.send_email_with_calendar(
-                                    req.get('cover_email'), 
-                                    cover_subject, 
-                                    cover_body,
-                                    req, 
-                                    is_for_requester=False
-                                )
-                                progress_bar.progress(100)
-                                
-                                st.success(f"Solicitud {req_id} aprobada por {supervisor_name_input_val}.")
-                                if not (email1 and email2):
-                                    st.warning("La aprobación fue guardada, pero hubo problemas al enviar algunas notificaciones por correo.")
-                                
-                                if 'pending_requests_data' in st.session_state:
-                                    del st.session_state.pending_requests_data
-                                st.rerun()
-                            else:
-                                st.error(f"Error al aprobar la solicitud {req_id}.")
+                        email1 = utils.send_email_with_calendar(
+                            req.get("requester_email"),
+                            requester_subject,
+                            requester_body,
+                            req,
+                            is_for_requester=True,
+                        )
+                        email2 = utils.send_email_with_calendar(
+                            req.get("cover_email"),
+                            cover_subject,
+                            cover_body,
+                            req,
+                            is_for_requester=False,
+                        )
+                        progress_bar.progress(100)
 
-                elif reject_submitted: # Check if reject button was pressed
-                    if not supervisor_name_input_val:
-                        st.warning("Por favor, ingresa tu nombre de supervisor.")
-                    elif supervisor_password_input_val != CORRECT_PASSWORD: # Use defined CORRECT_PASSWORD
-                        st.error("Contraseña del supervisor incorrecta.")
-                    elif not supervisor_comments_val: # Comments are mandatory for rejection
-                        st.warning("Por favor, añade un comentario explicando el motivo del rechazo.")
+                        st.success(
+                            f"Solicitud {req_id} aprobada por {supervisor_name_input_val}."
+                        )
+                        if not (email1 and email2):
+                            st.warning(
+                                "La aprobación fue guardada, pero hubo problemas al enviar algunas notificaciones por correo."
+                            )
+
+                        if "pending_requests_data" in st.session_state:
+                            del st.session_state.pending_requests_data
+                        st.rerun()
                     else:
-                        # rejection_container = st.container() # Not strictly necessary
-                        # with rejection_container:
-                        with st.spinner(f"Rechazando solicitud {req_id}..."):
-                            progress_bar = st.progress(0)
-                            st.caption("Actualizando estado en la base de datos...")
-                            now_utc = datetime.utcnow()
-                            updates = {
-                                "supervisor_status": "rejected",
-                                "supervisor_decision_date": now_utc.isoformat(),
-                                "supervisor_comments": supervisor_comments_val,
-                                "supervisor_name": supervisor_name_input_val
-                            }
-                            update_success = utils.update_shift_request_status(req_id, updates, PROJECT_ID)
-                            progress_bar.progress(50)
-                            
-                            if update_success:
-                                st.caption("Enviando notificaciones por correo...")
-                                fecha_rechazo = datetime.now().strftime("%d/%m/%Y")
-                                fecha_vuelo = utils.format_date(req.get('date_request'))
-                                fecha_aceptacion = utils.format_date(req.get('date_accepted_by_cover')) if req.get('date_accepted_by_cover') else "N/A"
-                                
-                                requester_subject = "❌ Cambio de Turno RECHAZADO"
-                                requester_body = f"""Hola {req.get('requester_name')},
+                        st.error(f"Error al aprobar la solicitud {req_id}.")
+
+        elif reject_submitted:
+            if not supervisor_name_input_val:
+                st.warning("Por favor, ingresa tu nombre de supervisor.")
+            elif supervisor_password_input_val != CORRECT_PASSWORD:
+                st.error("Contraseña del supervisor incorrecta.")
+            elif not supervisor_comments_val:
+                st.warning(
+                    "Por favor, añade un comentario explicando el motivo del rechazo."
+                )
+            else:
+                with st.spinner(f"Rechazando solicitud {req_id}..."):
+                    progress_bar = st.progress(0)
+                    st.caption("Actualizando estado en la base de datos...")
+                    now_utc = datetime.utcnow()
+                    updates = {
+                        "supervisor_status": "rejected",
+                        "supervisor_decision_date": now_utc.isoformat(),
+                        "supervisor_comments": supervisor_comments_val,
+                        "supervisor_name": supervisor_name_input_val,
+                    }
+                    update_success = utils.update_shift_request_status(
+                        req_id, updates, PROJECT_ID
+                    )
+                    progress_bar.progress(50)
+
+                    if update_success:
+                        st.caption("Enviando notificaciones por correo...")
+                        fecha_rechazo = datetime.now().strftime("%d/%m/%Y")
+                        fecha_vuelo = utils.format_date(req.get("date_request"))
+                        fecha_aceptacion = (
+                            utils.format_date(req.get("date_accepted_by_cover"))
+                            if req.get("date_accepted_by_cover")
+                            else "N/A"
+                        )
+
+                        requester_subject = "❌ Cambio de Turno RECHAZADO"
+                        requester_body = f"""Hola {req.get('requester_name')},
 
 Lamentamos informarte que tu solicitud de cambio de turno ha sido RECHAZADA.
 
@@ -287,8 +225,8 @@ Puedes presentar una nueva solicitud si consideras que las circunstancias han ca
 
 Saludos,
 ShiftTradeAV"""
-                                cover_subject = "❌ Cambio de Turno RECHAZADO"
-                                cover_body = f"""Hola {req.get('cover_name')},
+                        cover_subject = "❌ Cambio de Turno RECHAZADO"
+                        cover_body = f"""Hola {req.get('cover_name')},
 
 Te informamos que el cambio de turno que habías aceptado cubrir ha sido RECHAZADO por el supervisor.
 
@@ -310,110 +248,293 @@ Ya no necesitas cubrir este turno. Gracias por tu disposición.
 
 Saludos,
 ShiftTradeAV"""
-                                email1 = utils.send_email(req.get('requester_email'), requester_subject, requester_body)
-                                email2 = utils.send_email(req.get('cover_email'), cover_subject, cover_body)
-                                progress_bar.progress(100)
-                                
-                                st.success(f"Solicitud {req_id} rechazada por {supervisor_name_input_val}.")
-                                if not (email1 and email2):
-                                    st.warning("El rechazo fue guardado, pero hubo problemas al enviar algunas notificaciones por correo.")
-                                
-                                if 'pending_requests_data' in st.session_state:
-                                    del st.session_state.pending_requests_data
-                                st.rerun()
-                            else:
-                                st.error(f"Error al rechazar la solicitud {req_id}.")
-                st.markdown("---")
+                        email1 = utils.send_email(
+                            req.get("requester_email"),
+                            requester_subject,
+                            requester_body,
+                        )
+                        email2 = utils.send_email(
+                            req.get("cover_email"), cover_subject, cover_body
+                        )
+                        progress_bar.progress(100)
 
-elif st.session_state.view_mode == 'history_view':
+                        st.success(
+                            f"Solicitud {req_id} rechazada por {supervisor_name_input_val}."
+                        )
+                        if not (email1 and email2):
+                            st.warning(
+                                "El rechazo fue guardado, pero hubo problemas al enviar algunas notificaciones por correo."
+                            )
+
+                        if "pending_requests_data" in st.session_state:
+                            del st.session_state.pending_requests_data
+                        st.rerun()
+                    else:
+                        st.error(f"Error al rechazar la solicitud {req_id}.")
+
+    st.markdown("---")
+
+
+# Project ID for Supabase calls
+PROJECT_ID = "lperiyftrgzchrzvutgx"  # Replace with your actual Supabase project ID
+CORRECT_PASSWORD = "supervisor2025"
+
+st.set_page_config(page_title="Panel del Supervisor", page_icon="👑", layout="wide")
+
+# Password protection
+if "supervisor_password_correct" not in st.session_state:
+    st.session_state.supervisor_password_correct = False
+
+if not st.session_state.supervisor_password_correct:
+    st.title("👑 Acceso al Panel de Supervisor")
+    password_attempt = st.text_input(
+        "Ingrese la contraseña para acceder:",
+        type="password",
+        key="supervisor_page_password",
+    )
+    if password_attempt:
+        if password_attempt == CORRECT_PASSWORD:
+            st.session_state.supervisor_password_correct = True
+            st.rerun()
+        else:
+            st.error("Contraseña incorrecta.")
+    st.stop()  # Do not render the rest of the page if password is not correct
+
+# --- Main Page Content Starts Here ---
+st.title("👑 Panel de Aprobación del Supervisor")
+
+# Initialize session state for view mode if it doesn't exist
+if "view_mode" not in st.session_state:
+    st.session_state.view_mode = "pending_requests"  # Default view
+
+st.sidebar.header("Acciones")
+if st.sidebar.button("Refrescar Datos"):
+    # El método spinner no está disponible para st.sidebar
+    refresh_status = st.sidebar.empty()
+    refresh_status.info("Refrescando datos...")
+    # Clear relevant session state to force data refresh if needed
+    if "all_requests_for_history" in st.session_state:
+        del st.session_state.all_requests_for_history
+    if "pending_requests_data" in st.session_state:
+        del st.session_state.pending_requests_data
+    st.rerun()
+
+st.sidebar.markdown("---")
+
+# Sidebar buttons to switch views
+if st.sidebar.button("Ver Solicitudes Pendientes", key="view_pending"):
+    st.session_state.view_mode = "pending_requests"
+    st.rerun()
+
+if st.sidebar.button("Ver Historial de Solicitudes", key="view_history"):
+    st.session_state.view_mode = "history_view"
+    st.rerun()
+
+st.sidebar.markdown("---")
+
+# Main panel content based on view_mode
+if st.session_state.view_mode == "pending_requests":
+    st.header("Solicitudes Pendientes de Aprobación")
+    # 1. Display a list of all requests with `supervisor_status = 'pending'`
+    if "pending_requests_data" not in st.session_state:
+        with st.spinner("Cargando solicitudes pendientes..."):
+            st.session_state.pending_requests_data = utils.get_pending_requests(
+                PROJECT_ID
+            )
+
+    pending_requests = st.session_state.pending_requests_data
+
+    if not pending_requests:
+        st.info("No hay solicitudes de cambio de turno pendientes de aprobación.")
+        # Add a button to switch to history view if no pending requests
+        if st.button("Ver Historial de Solicitudes", key="pending_to_history_button"):
+            st.session_state.view_mode = "history_view"
+            st.rerun()
+    else:
+        st.subheader(f"Total Pendientes: {len(pending_requests)}")
+
+        # Ordenar solicitudes por fecha (más cercanas primero)
+        try:
+            for req in pending_requests:
+                if "date_request" in req:
+                    try:
+                        req["date_request_obj"] = datetime.fromisoformat(
+                            req["date_request"].replace("Z", "+00:00")
+                        )
+                    except (ValueError, AttributeError):
+                        req["date_request_obj"] = datetime(2099, 1, 1)
+                else:
+                    req["date_request_obj"] = datetime(2099, 1, 1)
+
+            pending_requests = sorted(
+                pending_requests, key=lambda x: x["date_request_obj"]
+            )
+        except Exception as e:
+            st.warning(f"No se pudieron ordenar las solicitudes por fecha: {e}")
+
+        accepted_by_cover = [
+            r
+            for r in pending_requests
+            if r.get("date_accepted_by_cover") not in (None, "N/A")
+        ]
+        awaiting_cover = [
+            r
+            for r in pending_requests
+            if r.get("date_accepted_by_cover") in (None, "N/A")
+        ]
+
+        if accepted_by_cover:
+            st.subheader("✅ Solicitudes con cubridor confirmado")
+            for req in accepted_by_cover:
+                render_pending_request(req)
+
+        if awaiting_cover:
+            st.subheader("⏳ Solicitudes pendientes de aceptación por el cubridor")
+            for req in awaiting_cover:
+                render_pending_request(req)
+
+        st.markdown("---")
+
+elif st.session_state.view_mode == "history_view":
     st.header("Historial de Todas las Solicitudes")
 
     # Fetch all requests (not just pending) for history, cache in session state
-    if 'all_requests_for_history' not in st.session_state:
+    if "all_requests_for_history" not in st.session_state:
         with st.spinner("Cargando historial de solicitudes..."):
-            st.session_state.all_requests_for_history = utils.get_all_shift_requests(PROJECT_ID)
-    
+            st.session_state.all_requests_for_history = utils.get_all_shift_requests(
+                PROJECT_ID
+            )
+
     all_requests_for_history = st.session_state.all_requests_for_history
 
     if not all_requests_for_history:
         st.info("No hay historial de solicitudes disponible.")
         # Add a button to switch to pending view if no history
         if st.button("Ver Solicitudes Pendientes", key="history_to_pending_button"):
-            st.session_state.view_mode = 'pending_requests'
+            st.session_state.view_mode = "pending_requests"
             st.rerun()
     else:
         # Convertir la lista de solicitudes a DataFrame para facilitar manipulación
         df_history = pd.DataFrame(all_requests_for_history)
-        
+
         # Ordenar por fecha de vuelo (convertir a datetime para ordenamiento correcto)
         try:
             # Convertir fecha_request a datetime para ordenar correctamente
-            df_history['date_request_dt'] = pd.to_datetime(df_history['date_request'], errors='coerce')
+            df_history["date_request_dt"] = pd.to_datetime(
+                df_history["date_request"], errors="coerce"
+            )
             # Ordenar por fecha ascendente (más cercanas primero)
-            df_history = df_history.sort_values(by='date_request_dt').reset_index(drop=True)
+            df_history = df_history.sort_values(by="date_request_dt").reset_index(
+                drop=True
+            )
             # Eliminar columna auxiliar usada para ordenar
-            df_history = df_history.drop('date_request_dt', axis=1)
+            df_history = df_history.drop("date_request_dt", axis=1)
         except Exception as e:
             st.warning(f"No se pudo ordenar el historial por fecha: {e}")
-        
+
         columns_to_display = [
-            'id', 'date_request', 'flight_number', 'requester_name', 
-            'cover_name', 'supervisor_status', 'supervisor_name', 
-            'supervisor_decision_date', 'supervisor_comments'
+            "id",
+            "date_request",
+            "flight_number",
+            "requester_name",
+            "cover_name",
+            "supervisor_status",
+            "supervisor_name",
+            "supervisor_decision_date",
+            "supervisor_comments",
         ]
-        existing_columns_in_df = [col for col in columns_to_display if col in df_history.columns]
-        
+        existing_columns_in_df = [
+            col for col in columns_to_display if col in df_history.columns
+        ]
+
         df_display_full = df_history[existing_columns_in_df].copy()
 
         # Convert relevant date columns to datetime objects and format with day name
-        if 'date_request' in df_display_full.columns: # Assuming this is the original shift date
+        if (
+            "date_request" in df_display_full.columns
+        ):  # Assuming this is the original shift date
             # Usar la función personalizada de formateo para todas las fechas
-            df_display_full['date_request'] = df_display_full['date_request'].apply(utils.format_date)
-        if 'supervisor_decision_date' in df_display_full.columns:
-            df_display_full['supervisor_decision_date'] = df_display_full['supervisor_decision_date'].apply(utils.format_date)
+            df_display_full["date_request"] = df_display_full["date_request"].apply(
+                utils.format_date
+            )
+        if "supervisor_decision_date" in df_display_full.columns:
+            df_display_full["supervisor_decision_date"] = df_display_full[
+                "supervisor_decision_date"
+            ].apply(utils.format_date)
 
         rename_map = {
-            'id': 'ID',
-            'date_request': 'Fecha Vuelo Orig.',
-            'flight_number': 'Vuelo',
-            'requester_name': 'Solicitante',
-            'cover_name': 'Cubridor',
-            'supervisor_status': 'Estado Sup.',
-            'supervisor_name': 'Supervisor',
-            'supervisor_decision_date': 'Fecha Decisión Sup.',
-            'supervisor_comments': 'Comentarios Sup.'
+            "id": "ID",
+            "date_request": "Fecha Vuelo Orig.",
+            "flight_number": "Vuelo",
+            "requester_name": "Solicitante",
+            "cover_name": "Cubridor",
+            "supervisor_status": "Estado Sup.",
+            "supervisor_name": "Supervisor",
+            "supervisor_decision_date": "Fecha Decisión Sup.",
+            "supervisor_comments": "Comentarios Sup.",
         }
-        df_display_filtered = df_display_full.rename(columns={k: v for k, v in rename_map.items() if k in df_display_full.columns})
-        
-        # Ensure the order of columns after renaming
-        ordered_renamed_columns = [rename_map[col] for col in existing_columns_in_df if col in rename_map and rename_map[col] in df_display_filtered.columns]
-        df_display_filtered = df_display_filtered[ordered_renamed_columns]
+        df_display_filtered = df_display_full.rename(
+            columns={
+                k: v for k, v in rename_map.items() if k in df_display_full.columns
+            }
+        )
 
+        # Ensure the order of columns after renaming
+        ordered_renamed_columns = [
+            rename_map[col]
+            for col in existing_columns_in_df
+            if col in rename_map and rename_map[col] in df_display_filtered.columns
+        ]
+        df_display_filtered = df_display_filtered[ordered_renamed_columns]
 
         st.markdown("### Filtrar Historial")
         filter_cols = st.columns(3)
-        
+
         with filter_cols[0]:
-            if 'Solicitante' in df_display_filtered.columns:
-                requester_names = sorted(df_display_filtered['Solicitante'].dropna().unique().tolist())
-                selected_requester = st.selectbox("Por Solicitante", ["Todos"] + requester_names, key="hist_requester_filter_main")
+            if "Solicitante" in df_display_filtered.columns:
+                requester_names = sorted(
+                    df_display_filtered["Solicitante"].dropna().unique().tolist()
+                )
+                selected_requester = st.selectbox(
+                    "Por Solicitante",
+                    ["Todos"] + requester_names,
+                    key="hist_requester_filter_main",
+                )
                 if selected_requester != "Todos":
-                    df_display_filtered = df_display_filtered[df_display_filtered['Solicitante'] == selected_requester]
-        
+                    df_display_filtered = df_display_filtered[
+                        df_display_filtered["Solicitante"] == selected_requester
+                    ]
+
         with filter_cols[1]:
-            if 'Cubridor' in df_display_filtered.columns:
-                cover_names = sorted(df_display_filtered['Cubridor'].dropna().unique().tolist())
-                selected_cover = st.selectbox("Por Cubridor", ["Todos"] + cover_names, key="hist_cover_filter_main")
+            if "Cubridor" in df_display_filtered.columns:
+                cover_names = sorted(
+                    df_display_filtered["Cubridor"].dropna().unique().tolist()
+                )
+                selected_cover = st.selectbox(
+                    "Por Cubridor",
+                    ["Todos"] + cover_names,
+                    key="hist_cover_filter_main",
+                )
                 if selected_cover != "Todos":
-                    df_display_filtered = df_display_filtered[df_display_filtered['Cubridor'] == selected_cover]
+                    df_display_filtered = df_display_filtered[
+                        df_display_filtered["Cubridor"] == selected_cover
+                    ]
 
         with filter_cols[2]:
-            if 'Estado Sup.' in df_display_filtered.columns:
-                status_options = sorted(df_display_filtered['Estado Sup.'].dropna().unique().tolist())
-                selected_status = st.selectbox("Por Estado Sup.", ["Todos"] + status_options, key="hist_status_filter_main")
+            if "Estado Sup." in df_display_filtered.columns:
+                status_options = sorted(
+                    df_display_filtered["Estado Sup."].dropna().unique().tolist()
+                )
+                selected_status = st.selectbox(
+                    "Por Estado Sup.",
+                    ["Todos"] + status_options,
+                    key="hist_status_filter_main",
+                )
                 if selected_status != "Todos":
-                    df_display_filtered = df_display_filtered[df_display_filtered['Estado Sup.'] == selected_status]
-        
+                    df_display_filtered = df_display_filtered[
+                        df_display_filtered["Estado Sup."] == selected_status
+                    ]
+
         st.dataframe(df_display_filtered, use_container_width=True)
 
 st.markdown("---")


### PR DESCRIPTION
## Summary
- restrict trade date selection to at least 24h in advance
- use dropdowns for RAIC color for requester and cover
- enforce RAIC logic so green RAIC can only cover green
- group supervisor pending requests by cover acceptance

## Testing
- `black 1_Formulario.py pages/3_Supervisor.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'supabase')*

------
https://chatgpt.com/codex/tasks/task_e_684992b555f4832bb640e410e6243c07