### PR TITLE
Add config module for env-based constants

### DIFF
--- a/1_Formulario.py
+++ b/1_Formulario.py
@@ -2,9 +2,10 @@ import streamlit as st
 from datetime import datetime, timedelta
 import re
 import utils  # Your utility functions for Supabase, tokens, and email
+import config
 
 # Project ID for Supabase calls
-PROJECT_ID = "lperiyftrgzchrzvutgx"  # Replace with your actual Supabase project ID
+PROJECT_ID = config.PROJECT_ID
 
 
 # Function to validate email format

--- a/config.py
+++ b/config.py
@@ -1,0 +1,10 @@
+import os
+import streamlit as st
+
+def get_config_value(name, default=None):
+    """Retrieve configuration value from environment variable or Streamlit secrets."""
+    return os.getenv(name) or st.secrets.get(name, default)
+
+PROJECT_ID = get_config_value("PROJECT_ID")
+SUPERVISOR_PASSWORD = get_config_value("SUPERVISOR_PASSWORD")
+ADMIN_PASSWORD = get_config_value("ADMIN_PASSWORD")

--- a/pages/2_Solicitud.py
+++ b/pages/2_Solicitud.py
@@ -2,7 +2,8 @@ import streamlit as st
 from datetime import datetime
 
 try:
-    import utils # Your utility functions
+import utils # Your utility functions
+import config
 except st.errors.StreamlitSecretNotFoundError as e:
     st.error(
         "CRITICAL ERROR: Could not load application secrets required by 'utils.py'.\n"
@@ -18,7 +19,7 @@ except ImportError as e:
     st.stop()
 
 # Project ID for Supabase calls
-PROJECT_ID = "lperiyftrgzchrzvutgx" # Replace with your actual Supabase project ID
+PROJECT_ID = config.PROJECT_ID
 
 st.set_page_config(
     page_title="Aceptar Cambio",

--- a/pages/3_Supervisor.py
+++ b/pages/3_Supervisor.py
@@ -2,6 +2,7 @@ import streamlit as st
 import pandas as pd  # Import pandas for DataFrame
 from datetime import datetime
 import utils  # Your utility functions
+import config
 
 
 def render_pending_request(req):
@@ -276,8 +277,8 @@ ShiftTradeAV"""
 
 
 # Project ID for Supabase calls
-PROJECT_ID = "lperiyftrgzchrzvutgx"  # Replace with your actual Supabase project ID
-CORRECT_PASSWORD = "supervisor2025"
+PROJECT_ID = config.PROJECT_ID
+CORRECT_PASSWORD = config.SUPERVISOR_PASSWORD
 
 st.set_page_config(page_title="Panel del Supervisor", page_icon="👑", layout="wide")
 

--- a/pages/4_Admin_Empleados.py
+++ b/pages/4_Admin_Empleados.py
@@ -1,9 +1,11 @@
 import streamlit as st
 import re
 import utils
+import config
 
 # Project ID for Supabase calls
-PROJECT_ID = "lperiyftrgzchrzvutgx"
+PROJECT_ID = config.PROJECT_ID
+ADMIN_PASSWORD = config.ADMIN_PASSWORD
 
 # Function to validate email format
 def validate_email(email):
@@ -37,7 +39,7 @@ if not st.session_state.admin_authenticated:
     admin_password = st.text_input("Contraseña de administrador", type="password")
     
     if st.button("Acceder"):
-        if admin_password == "admin123":  # You should use a more secure password
+        if admin_password == ADMIN_PASSWORD:
             st.session_state.admin_authenticated = True
             st.success("✅ Acceso concedido")
             st.rerun()

--- a/pages/5_Historial.py
+++ b/pages/5_Historial.py
@@ -8,9 +8,10 @@ import os
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 import utils
+import config
 
 # Project ID (ensure this is consistent, or pass it around/get from a central config)
-PROJECT_ID = "lperiyftrgzchrzvutgx"
+PROJECT_ID = config.PROJECT_ID
 
 st.set_page_config(
     page_title="Historial de Cambios",


### PR DESCRIPTION
## Summary
- add `config.py` to retrieve configuration from env vars or Streamlit secrets
- use `config.PROJECT_ID` everywhere instead of hardcoded IDs
- use `config.SUPERVISOR_PASSWORD` in supervisor page
- centralise admin password via `config.ADMIN_PASSWORD`

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'supabase')*

------
https://chatgpt.com/codex/tasks/task_e_684a07836084832bb7ad2335bfbd497b